### PR TITLE
Switching from Alpine to Debian

### DIFF
--- a/8-stretch-slim/Dockerfile
+++ b/8-stretch-slim/Dockerfile
@@ -5,26 +5,21 @@ ARG GIFSICLE_VERSION=1.91
 
 RUN apt-get update -qq \
     && apt-get install -y build-essential graphicsmagick-libmagick-dev-compat libexpat1-dev libfftw3-dev \
-    liborc-0.4-dev libpng-dev libtiff5-dev pngquant automake gtk-doc-tools \
+    liborc-0.4-dev libpng-dev libtiff5-dev pngquant automake gtk-doc-tools libglib2.0-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
 
 # Install vips, an image processing library
-# https://jcupitt.github.io/libvips/install.html (doesn't work properly)
-# https://github.com/libvips/libvips/wiki/Build-for-Ubuntu (worked)
-# We use a fork of libvips because when we wrote this, the script we based this on did as well.
-# We might not need to anymore, but if it still works we're good
-ADD https://github.com/jcupitt/libvips/archive/v${VIPS_VERSION}.tar.gz vips.tar.gz
+# https://github.com/libvips/libvips/releases/tag/v8.6.3
+# If there are problems with images types being unsupported, we might want to try the 'all' or 'web' versions.
+ADD https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz vips.tar.gz
 RUN tar xf vips.tar.gz \
-    && cd libvips-${VIPS_VERSION} \
-    && ./autogen.sh
-    && make && make install \
-    && ldconfig /usr/local/lib \
-    && make clean \
-    && make -s install-strip \
-    && cd ..
+  && cd vips-${VIPS_VERSION} \
+  && ./configure --disable-static \
+  && make && make install && make clean \
+  && cd ..
 
 # Install Gifsicle, a package to create, manipulate and optimise GIF images
 # http://www.lcdf.org/gifsicle/

--- a/8-stretch-slim/Dockerfile
+++ b/8-stretch-slim/Dockerfile
@@ -1,0 +1,41 @@
+FROM articulate/articulate-node:8-stretch-slim
+ARG VIPS_VERSION=8.6.3
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ARG gifsicle_version=1.91
+
+RUN apt-get update && \
+    apt-get install -y build-essential graphicsmagick-libmagick-dev-compat libexpat1-dev libfftw3-dev liborc-0.4-dev libpng-dev libtiff5-dev pngquant && \
+    apt-get clean
+
+WORKDIR /tmp
+
+# Install vips, an image processing library
+# https://jcupitt.github.io/libvips/install.html
+# RUN mkdir -p vips && \
+#    curl -Ls https://github.com/jcupitt/libvips/releases/download/v${vips_version}/vips-${vips_version}.tar.gz | tar xzC vips --strip-components=1 && \
+#    cd vips && \
+#    ./configure --disable-static && \
+#    make && make install && make clean && \
+#    cd ..
+
+ADD https://github.com/jcupitt/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz vips.tar.gz
+
+RUN tar xvzf vips.tar.gz \
+    && cd vips-${VIPS_VERSION} \
+    && ./configure --disable-static \
+    && make && make install \
+    && ldconfig /usr/local/lib \
+    && make clean \
+    && make -s install-strip \
+    && cd .. \
+    && rm -rf vips*
+
+ADD https://github.com/kohler/gifsicle/archive/v${gifsicle_version}.zip gifsicle.zip
+RUN unzip gifsicle.zip && \
+    cd gifsicle-${gifsicle_version} && \
+    autoreconf -i && \
+    ./configure --disable-gifview --disable-gifdiff && \
+    make install
+
+RUN rm -rf /tmp/*
+WORKDIR $SERVICE_ROOT

--- a/8-stretch-slim/Dockerfile
+++ b/8-stretch-slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM articulate/articulate-node:8-stretch-slim
 ARG VIPS_VERSION=8.6.3
 ENV LD_LIBRARY_PATH=/usr/local/lib
-ARG gifsicle_version=1.91
+ARG GIFSICLE_VERSION=1.91
 
 RUN apt-get update -qq \
     && apt-get install -y build-essential graphicsmagick-libmagick-dev-compat libexpat1-dev libfftw3-dev \
@@ -26,12 +26,14 @@ RUN tar xf vips.tar.gz \
     && make -s install-strip \
     && cd ..
 
-#ADD https://github.com/kohler/gifsicle/archive/v${gifsicle_version}.zip gifsicle.zip
-#RUN unzip gifsicle.zip && \
-#    cd gifsicle-${gifsicle_version} && \
-#    autoreconf -i && \
-#    ./configure --disable-gifview --disable-gifdiff && \
-#    make install
-#
-#RUN rm -rf /tmp/*
-#WORKDIR $SERVICE_ROOT
+# Install Gifsicle, a package to create, manipulate and optimise GIF images
+# http://www.lcdf.org/gifsicle/
+ADD https://github.com/kohler/gifsicle/archive/v${GIFSICLE_VERSION}.tar.gz gifsicle.tar.gz
+RUN tar xf gifsicle.tar.gz && \
+    cd gifsicle-${GIFSICLE_VERSION} && \
+    autoreconf -i && \
+    ./configure --disable-gifview --disable-gifdiff && \
+    make install
+
+RUN rm -rf /tmp/*
+WORKDIR $SERVICE_ROOT

--- a/8-stretch-slim/Dockerfile
+++ b/8-stretch-slim/Dockerfile
@@ -3,39 +3,35 @@ ARG VIPS_VERSION=8.6.3
 ENV LD_LIBRARY_PATH=/usr/local/lib
 ARG gifsicle_version=1.91
 
-RUN apt-get update && \
-    apt-get install -y build-essential graphicsmagick-libmagick-dev-compat libexpat1-dev libfftw3-dev liborc-0.4-dev libpng-dev libtiff5-dev pngquant && \
-    apt-get clean
+RUN apt-get update -qq \
+    && apt-get install -y build-essential graphicsmagick-libmagick-dev-compat libexpat1-dev libfftw3-dev \
+    liborc-0.4-dev libpng-dev libtiff5-dev pngquant automake gtk-doc-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
 
 # Install vips, an image processing library
-# https://jcupitt.github.io/libvips/install.html
-# RUN mkdir -p vips && \
-#    curl -Ls https://github.com/jcupitt/libvips/releases/download/v${vips_version}/vips-${vips_version}.tar.gz | tar xzC vips --strip-components=1 && \
-#    cd vips && \
-#    ./configure --disable-static && \
-#    make && make install && make clean && \
-#    cd ..
-
-ADD https://github.com/jcupitt/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz vips.tar.gz
-
-RUN tar xvzf vips.tar.gz \
-    && cd vips-${VIPS_VERSION} \
-    && ./configure --disable-static \
+# https://jcupitt.github.io/libvips/install.html (doesn't work properly)
+# https://github.com/libvips/libvips/wiki/Build-for-Ubuntu (worked)
+# We use a fork of libvips because when we wrote this, the script we based this on did as well.
+# We might not need to anymore, but if it still works we're good
+ADD https://github.com/jcupitt/libvips/archive/v${VIPS_VERSION}.tar.gz vips.tar.gz
+RUN tar xf vips.tar.gz \
+    && cd libvips-${VIPS_VERSION} \
+    && ./autogen.sh
     && make && make install \
     && ldconfig /usr/local/lib \
     && make clean \
     && make -s install-strip \
-    && cd .. \
-    && rm -rf vips*
+    && cd ..
 
-ADD https://github.com/kohler/gifsicle/archive/v${gifsicle_version}.zip gifsicle.zip
-RUN unzip gifsicle.zip && \
-    cd gifsicle-${gifsicle_version} && \
-    autoreconf -i && \
-    ./configure --disable-gifview --disable-gifdiff && \
-    make install
-
-RUN rm -rf /tmp/*
-WORKDIR $SERVICE_ROOT
+#ADD https://github.com/kohler/gifsicle/archive/v${gifsicle_version}.zip gifsicle.zip
+#RUN unzip gifsicle.zip && \
+#    cd gifsicle-${gifsicle_version} && \
+#    autoreconf -i && \
+#    ./configure --disable-gifview --disable-gifdiff && \
+#    make install
+#
+#RUN rm -rf /tmp/*
+#WORKDIR $SERVICE_ROOT


### PR DESCRIPTION
We're switching our Docker images from Alpine to Debian-slim.
Debian is much more on point when it comes to security, and we want to make use of that.